### PR TITLE
Add Buzzer, Speaker, and Vibrator classes with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,164 @@
 # ArduinoCommon
 
-Arduino common libraries
+Arduino 向けの共通ライブラリ集です。  
+ESP32 を中心に、複数プロジェクトで再利用する部品をまとめています。
 
 ---
 
-## Timer
+## 含まれるライブラリ
 
-例えばメインループで特定の周期で実行したい処理がある場合に使用する。
+### Timer
 
-[Timer使用例](examples/Timer/Timer.ino)
+一定周期の判定や経過時間の計測を行うユーティリティです。
+
+- 周期実行判定
+- 開始からの経過時間取得
+- グローバル時刻取得
+
+使用例: `examples/Timer/Timer.ino`
+
+### ServoESP32
+
+ESP32 の LEDC を使って RC サーボを制御します。
+
+- 角度指定
+- 角速度を考慮した追従制御
+
+使用例: `examples/ServoESP32/ServoESP32.ino`
+
+### WiFiESP32
+
+ESP32 の Wi-Fi 接続を扱う補助クラスです。接続や状態確認を簡潔に扱えます。
+
+使用例: `examples/WiFiESP32/WiFiESP32.ino`
+
+### EEPROMStore
+
+構造体データを EEPROM に保存・復元するためのテンプレートクラスです。
+
+- デフォルト値からの初期化
+- CRC16 による破損検出
+- 更新時のみ書き込み
+- 複数ストアの連結利用
+
+使用例: `examples/EEPROMStore/BasicUsage/BasicUsage.ino`
 
 ---
 
-## ServoESP32
+## 音と振動の出力
 
-ESP32マイコンでRCサーボモータを駆動するときに使用する。
+### TimedPatternPlayer
 
-- -90°～90°の角度を指定可能
-- 回転角速度[°/s]を指定可能
+時間付きの出力シーケンスをノンブロッキングで再生する共通基底クラスです。  
+`Buzzer` と `Vibrator` はこのクラスを利用しており、どちらも `update()` を周期的に呼ぶだけで再生できます。
 
-[ServoESP32使用例](examples/ServoESP32/ServoESP32.ino)
+### Buzzer
 
----
+MIDI ノート番号ベースでブザーを制御します。
 
-## WiFiESP32
-
-ESP32マイコンでWiFiを使用するライブラリ。再接続処理などを実装。
-
-[WiFiESP32使用例](examples/WiFiESP32/WiFiESP32.ino)
-
----
-
-## EEPROMStore
-
-任意の構造体をEEPROMに安全に読み書きするArduinoライブラリ。
-
-### 特徴
-
-- **テンプレート対応** — 任意の構造体をそのまま保存・読み込み
-- **CRC16整合性チェック** — データ破損を検知し、デフォルト値で自動復旧
-- **マジックナンバー** — 未初期化EEPROMとの区別、複数ストアの識別
-- **差分書き込み** — AVRでは `EEPROM.put()` 内部の `update()` によりバイト単位で差分書き込み
-- **マルチプラットフォーム** — AVR / ESP32 / ESP8266 対応
-
-### 基本的な使い方
+- 単音再生: `playTone()`
+- 停止: `mute()`
+- メロディ再生: `playMelody()`
+- 再生更新: `update()`
 
 ```cpp
-#include <EEPROMStore.h>
+#include <Buzzer.h>
 
-struct Config {
-    int   interval;
-    float threshold;
-    char  name[16];
+Buzzer buzzer;
+
+const Buzzer::Note melody[] = {
+    {72, 100},
+    {Buzzer::REST, 50},
+    {76, 100},
 };
 
-Config defaults = { 1000, 25.5f, "sensor01" };
-EEPROMStore<Config> store(0, defaults);
-
 void setup() {
-    store.begin();              // 読み込み（初回はデフォルトで初期化）
-    store.data.threshold = 30;  // 値を変更
-    store.save();               // 変更があれば書き込み
+  buzzer.begin();
+  buzzer.playMelody(melody);
+}
+
+void loop() {
+  buzzer.update();
 }
 ```
 
-### API
+使用例: `examples/Buzzer/Buzzer.ino`
 
-| メソッド | 説明 |
-| --- | --- |
-| `EEPROMStore<T>(address, defaults, magic)` | コンストラクタ。`magic` は省略可（デフォルト `0xBEEF`） |
-| `bool begin()` | 読み込み。失敗時はデフォルトで初期化。戻り値: 既存データの有無 |
-| `bool save()` | CRC比較で変更時のみ書き込み。戻り値: 書き込みの有無 |
-| `void forceSave()` | 比較なしで強制書き込み |
-| `void reset()` | デフォルト値に戻して書き込み |
-| `static uint16_t requiredSize()` | ストアが使用するバイト数 |
-| `uint16_t nextAddress()` | 次のストアの開始アドレス |
-| `T data` | 読み書き対象の構造体（直接アクセス） |
+### Vibrator
 
-### 複数ストアの配置
+出力強度[%] と再生時間[ms] の組み合わせで振動を制御します。
+
+- 全開出力: `on()`
+- 強度指定: `setPower()`
+- 停止: `off()`
+- パターン再生: `playPattern()`
+- 再生更新: `update()`
 
 ```cpp
-EEPROMStore<SensorConfig>  sensor(0, sensorDefaults, 0xAA01);
-EEPROMStore<NetworkConfig> network(sensor.nextAddress(), networkDefaults, 0xAA02);
+#include <Vibrator.h>
+
+Vibrator vibrator(12, 3);
+
+const Vibrator::PowerStep pattern[] = {
+    {100, 80},
+    {0, 40},
+    {60, 160},
+};
+
+void setup() {
+  vibrator.begin();
+  vibrator.playPattern(pattern);
+}
+
+void loop() {
+  vibrator.update();
+}
 ```
 
-### 対応アーキテクチャ
+使用例: `examples/Vibrator/Vibrator.ino`
 
-AVR, ESP32, ESP8266, その他 EEPROM.h 互換ボード
+### Speaker
+
+`Speaker` は `Buzzer` を継承し、トーン再生に加えて DAC を使った WAV 再生にも対応します。
+
+- ブザー互換のメロディ再生
+- 音量設定: `setVolume()`
+- WAV 再生予約: `requestWav()`
+- WAV 再生更新: `updateWav()`
+
+```cpp
+#include <Speaker.h>
+
+Speaker speaker(80);
+
+const Buzzer::Note melody[] = {
+    {72, 100},
+    {76, 100},
+    {79, 200},
+};
+
+void setup() {
+  speaker.begin();
+  speaker.playMelody(melody);
+}
+
+void loop() {
+  speaker.updateWav();
+  speaker.update();
+}
+```
+
+使用例: `examples/Speaker/Speaker.ino`
+
+---
+
+## 対応環境
+
+- AVR
+- ESP32
+- ESP8266
+
+ライブラリごとに利用できる機能は異なります。`Buzzer` / `Vibrator` / `Speaker` は ESP32 向け実装です。
 
 ---
 

--- a/examples/Buzzer/Buzzer.ino
+++ b/examples/Buzzer/Buzzer.ino
@@ -1,0 +1,22 @@
+#include <Buzzer.h>
+
+Buzzer buzzer;
+
+const Buzzer::Note melody[] = {
+    {72, 120},
+    {Buzzer::REST, 80},
+    {76, 120},
+    {79, 240},
+};
+
+void setup() {
+  buzzer.begin();
+  buzzer.playMelody(melody);
+}
+
+void loop() {
+  if (!buzzer.update()) {
+    delay(1000);
+    buzzer.playMelody(melody);
+  }
+}

--- a/examples/Speaker/Speaker.ino
+++ b/examples/Speaker/Speaker.ino
@@ -1,0 +1,23 @@
+#include <Speaker.h>
+
+Speaker speaker(80);
+
+const Buzzer::Note melody[] = {
+    {72, 100},
+    {76, 100},
+    {79, 200},
+};
+
+void setup() {
+  speaker.begin();
+  speaker.playMelody(melody);
+}
+
+void loop() {
+  speaker.updateWav();
+
+  if (!speaker.update()) {
+    delay(1000);
+    speaker.playMelody(melody);
+  }
+}

--- a/examples/Vibrator/Vibrator.ino
+++ b/examples/Vibrator/Vibrator.ino
@@ -1,0 +1,21 @@
+#include <Vibrator.h>
+
+Vibrator vibrator(12, 3);
+
+const Vibrator::PowerStep pattern[] = {
+    {100, 80},
+    {0, 40},
+    {60, 160},
+};
+
+void setup() {
+  vibrator.begin();
+  vibrator.playPattern(pattern);
+}
+
+void loop() {
+  if (!vibrator.update()) {
+    delay(1000);
+    vibrator.playPattern(pattern);
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino Common Library
-version=0.4.1
+version=0.5.0
 author=Tatsuya Miyazaki
 maintainer=Tatsuya Miyazaki <miyazaki.tatsuya.mail@gmail.com>
 sentence=This is common libraries for Arduino.

--- a/src/Buzzer.cpp
+++ b/src/Buzzer.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file Buzzer.cpp
+ * @brief MIDI ノート番号ベースでブザーを制御するクラスの実装
+ */
+
+#include "Buzzer.h"
+
+/**
+ * @brief MIDI ノート番号を周波数へ変換するテーブル
+ */
+const double Buzzer::MIDI_TO_FREQ[] = {
+    8.2,     8.7,    9.2,    9.7,    10.3,   10.9,   11.6,   12.2,    13,
+    13.8,    14.6,   15.4,   16.4,   17.3,   18.4,   19.4,   20.6,    21.8,
+    23.1,    24.5,   26,     27.5,   29.1,   30.9,   32.7,   34.6,    36.7,
+    38.9,    41.2,   43.7,   46.2,   49,     51.9,   55,     58.3,    61.7,
+    65.4,    69.3,   73.4,   77.8,   82.4,   87.3,   92.5,   98,      103.8,
+    110,     116.5,  123.5,  130.8,  138.6,  146.8,  155.6,  164.8,   174.6,
+    185,     196,    207.7,  220,    233.1,  246.9,  261.6,  277.2,   293.7,
+    311.1,   329.6,  349.2,  370,    392,    415.3,  440,    466.2,   493.9,
+    523.3,   554.4,  587.3,  622.3,  659.3,  698.5,  740,    784,     830.6,
+    880,     932.3,  987.8,  1046.5, 1108.7, 1174.7, 1244.5, 1318.5,  1396.9,
+    1480,    1568,   1661.2, 1760,   1864.7, 1975.5, 2093,   2217.5,  2349.3,
+    2489,    2637,   2793.8, 2960,   3136,   3322.4, 3520,   3729.3,  3951.1,
+    4186,    4434.9, 4698.6, 4978,   5274,   5587.7, 5919.9, 6271.9,  6644.9,
+    7040,    7458.6, 7902.1, 8372,   8869.8, 9397.3, 9956.1, 10548.1, 11175.3,
+    11839.8, 12543.9};
+
+Buzzer::Buzzer(uint8_t pin, uint8_t channel, uint16_t baseFrequency,
+               uint8_t resolutionBits)
+    : _pin(pin),
+      _channel(channel),
+      _baseFrequency(baseFrequency),
+      _resolutionBits(resolutionBits),
+      _begun(false) {}
+
+Buzzer::~Buzzer() {}
+
+/**
+ * @brief LEDC と出力ピンを初期化する
+ */
+void Buzzer::begin() {
+  if (_begun) {
+    return;
+  }
+
+  ledcSetup(_channel, _baseFrequency, _resolutionBits);
+  attach();
+  _begun = true;
+  mute();
+}
+
+/**
+ * @brief 単音を再生する
+ * @param midiNote MIDI ノート番号。`REST` の場合は無音
+ */
+void Buzzer::playTone(uint8_t midiNote) {
+  begin();
+
+  if (midiNote == REST) {
+    mute();
+  } else if (midiNote >= MIDI_NOTE_MIN && midiNote <= MIDI_NOTE_MAX) {
+    ledcWriteTone(_channel, MIDI_TO_FREQ[midiNote]);
+  }
+}
+
+/**
+ * @brief ブザー出力を停止する
+ */
+void Buzzer::mute() {
+  begin();
+  ledcWriteTone(_channel, 0.0);
+}
+
+/**
+ * @brief メロディ再生を開始する
+ * @param melody メロディ配列
+ * @param length 配列長
+ */
+void Buzzer::playMelody(const Note* melody, size_t length) {
+  play(melody, length);
+}
+
+void Buzzer::playMelody(Melody melody) {
+  play(melody);
+}
+
+/**
+ * @brief メロディ再生状態を更新する
+ * @return true 再生中
+ * @return false 停止中または再生完了
+ */
+bool Buzzer::update() {
+  begin();
+  return TimedPatternPlayer::update();
+}
+
+Buzzer::Melody Buzzer::captureMelody() const {
+  return capturePlayback();
+}
+
+/**
+ * @brief 現在のステップ値をブザー出力へ反映する
+ * @param output MIDI ノート番号
+ */
+void Buzzer::applyOutput(uint8_t output) {
+  playTone(output);
+}
+
+void Buzzer::stopOutput() {
+  mute();
+}
+
+/**
+ * @brief ブザー出力ピンを LEDC チャンネルへ接続する
+ */
+void Buzzer::attach() {
+  ledcAttachPin(_pin, _channel);
+}
+
+/**
+ * @brief ブザー出力ピンを LEDC チャンネルから切り離す
+ */
+void Buzzer::detach() {
+  ledcDetachPin(_pin);
+}

--- a/src/Buzzer.h
+++ b/src/Buzzer.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Arduino.h>
+#include <stddef.h>
+
+#include "TimedPatternPlayer.h"
+
+class Buzzer : public TimedPatternPlayer {
+ public:
+  using Note = TimedPatternPlayer::Step;
+  using Melody = TimedPatternPlayer::Pattern;
+
+  static const uint8_t REST = 0;
+  static const uint8_t DEFAULT_PIN = 14;
+  static const uint8_t DEFAULT_CHANNEL = 2;
+  static const uint8_t DEFAULT_RESOLUTION_BITS = 13;
+  static const uint16_t DEFAULT_BASE_FREQ = 5000;
+
+  Buzzer(uint8_t pin = DEFAULT_PIN, uint8_t channel = DEFAULT_CHANNEL,
+         uint16_t baseFrequency = DEFAULT_BASE_FREQ,
+         uint8_t resolutionBits = DEFAULT_RESOLUTION_BITS);
+  virtual ~Buzzer();
+
+  void begin();
+  void playTone(uint8_t midiNote);
+  void mute();
+  void playMelody(const Note* melody, size_t length);
+  void playMelody(Melody melody);
+  template <size_t N>
+  void playMelody(const Note (&melody)[N]) {
+    playMelody(melody, N);
+  }
+  bool update() override;
+  Melody captureMelody() const;
+
+ protected:
+  void applyOutput(uint8_t output) override;
+  void stopOutput() override;
+  void attach();
+  void detach();
+
+ private:
+  static const uint8_t MIDI_NOTE_MIN = 59;
+  static const uint8_t MIDI_NOTE_MAX = 109;
+  static const double MIDI_TO_FREQ[];
+
+  uint8_t _pin;
+  uint8_t _channel;
+  uint16_t _baseFrequency;
+  uint8_t _resolutionBits;
+  bool _begun;
+};

--- a/src/Speaker.cpp
+++ b/src/Speaker.cpp
@@ -1,0 +1,244 @@
+/**
+ * @file Speaker.cpp
+ * @brief ブザー互換のトーン再生と DAC による WAV 再生を行うクラスの実装
+ */
+
+#include "Speaker.h"
+
+#include <Log.h>
+#include <string.h>
+
+Speaker::Speaker(uint8_t volumePercent, uint8_t speakerPin,
+                 uint8_t shutdownPin, uint8_t channel)
+    : Buzzer(speakerPin, channel),
+      _shutdownPin(shutdownPin),
+      _audio(nullptr),
+      _length(0),
+      _playRequested(false),
+      _volumeInitialized(false),
+      _initialVolume(volumePercent),
+      _begun(false) {}
+
+Speaker::~Speaker() {}
+
+/**
+ * @brief スピーカー出力・ボリューム制御・I2C を初期化する
+ */
+void Speaker::begin() {
+  if (_begun) {
+    return;
+  }
+
+  Buzzer::begin();
+  setOutputMode(TONE_OUTPUT);
+  pinMode(_shutdownPin, OUTPUT);
+  enable();
+  Wire.begin();
+  _begun = true;
+}
+
+/**
+ * @brief スピーカーアンプを有効化する
+ */
+void Speaker::enable() {
+  if (!digitalRead(_shutdownPin)) {
+    digitalWrite(_shutdownPin, HIGH);
+  }
+}
+
+/**
+ * @brief スピーカーアンプを無効化する
+ */
+void Speaker::disable() {
+  if (digitalRead(_shutdownPin)) {
+    digitalWrite(_shutdownPin, LOW);
+  }
+}
+
+/**
+ * @brief デジタルボリュームへ音量を設定する
+ * @param percent 音量[%]
+ */
+void Speaker::setVolume(uint8_t percent) {
+  if (percent > 100) {
+    percent = 100;
+  }
+
+  uint16_t value = 127 * (uint16_t)percent / 100;
+  Wire.beginTransmission(0x2F);
+  Wire.write(value);
+  Wire.endTransmission();
+
+  logger.info("Speaker::setVolume(): volume = " + String(percent) +
+              ", value = " + String(value));
+}
+
+/**
+ * @brief WAV データ再生を予約する
+ * @param audio WAV バイト列
+ * @param length データ長
+ */
+void Speaker::requestWav(const unsigned char* audio, uint32_t length) {
+  _audio = audio;
+  _length = length;
+  _playRequested = true;
+}
+
+/**
+ * @brief 再生予約された WAV を処理する
+ * @return true WAV 再生を開始した
+ * @return false 再生予約なし
+ */
+bool Speaker::updateWav() {
+  begin();
+  initVolume();
+
+  if (!takeRequest()) {
+    return false;
+  }
+
+  playWav(_audio, _length);
+  return true;
+}
+
+/**
+ * @brief ブザー互換のメロディ再生状態を更新する
+ * @return true 再生中
+ * @return false 停止中または再生完了
+ */
+bool Speaker::update() {
+  begin();
+  initVolume();
+  return Buzzer::update();
+}
+
+/**
+ * @brief 初回のみ初期音量を設定する
+ */
+void Speaker::initVolume() {
+  if (!_volumeInitialized) {
+    _volumeInitialized = true;
+    setVolume(_initialVolume);
+  }
+}
+
+/**
+ * @brief 出力経路をトーン再生か WAV 再生へ切り替える
+ * @param mode 出力モード
+ */
+void Speaker::setOutputMode(OutputMode mode) {
+  switch (mode) {
+    case TONE_OUTPUT:
+      dac_output_disable(DAC_CHANNEL_1);
+      attach();
+      break;
+    case WAV_OUTPUT:
+      detach();
+      dac_output_enable(DAC_CHANNEL_1);
+      break;
+  }
+}
+
+/**
+ * @brief WAV データを DAC へ逐次出力して再生する
+ * @param audio WAV バイト列
+ * @param length データ長
+ * @return int 1: 正常終了, 0: 再生中断, -1: フォーマット不正
+ */
+int Speaker::playWav(const unsigned char* audio, uint32_t length) {
+  if (audio == nullptr || length == 0) {
+    return -1;
+  }
+
+  initVolume();
+  setOutputMode(WAV_OUTPUT);
+
+  if (strncmp((const char*)audio, "RIFF", 4)) {
+    Serial.println("Error: It is not RIFF.");
+    setOutputMode(TONE_OUTPUT);
+    return -1;
+  }
+
+  if (strncmp((const char*)audio + 8, "WAVE", 4)) {
+    Serial.println("Error: It is not WAVE.");
+    setOutputMode(TONE_OUTPUT);
+    return -1;
+  }
+
+  if (strncmp((const char*)audio + 12, "fmt ", 4)) {
+    Serial.println("Error: fmt not found.");
+    setOutputMode(TONE_OUTPUT);
+    return -1;
+  }
+
+  uint32_t chunkSize;
+  uint16_t numChannels;
+  uint32_t sampleRate;
+  uint16_t bitsPerSample;
+  memcpy(&chunkSize, (const char*)audio + 16, sizeof(chunkSize));
+  memcpy(&numChannels, (const char*)audio + 22, sizeof(numChannels));
+  memcpy(&sampleRate, (const char*)audio + 24, sizeof(sampleRate));
+  memcpy(&bitsPerSample, (const char*)audio + 34, sizeof(bitsPerSample));
+
+  uint32_t count = 16 + sizeof(chunkSize) + chunkSize;
+  while (count + 8 <= length && strncmp((const char*)audio + count, "data", 4)) {
+    count += 4;
+    memcpy(&chunkSize, (const char*)audio + count, sizeof(chunkSize));
+    count += sizeof(chunkSize) + chunkSize;
+  }
+
+  if (count + 8 > length) {
+    setOutputMode(TONE_OUTPUT);
+    return -1;
+  }
+
+  count += 4 + sizeof(chunkSize);
+  uint16_t delayus = 1000000 / sampleRate;
+
+  while (count < length) {
+    uint8_t left;
+    if (bitsPerSample == 16) {
+      uint16_t data16;
+      memcpy(&data16, (const char*)audio + count, sizeof(data16));
+      left = ((uint16_t)data16 + 32767) >> 8;
+      count += sizeof(data16);
+      if (numChannels == 2) {
+        count += sizeof(data16);
+      }
+    } else {
+      uint8_t data8;
+      memcpy(&data8, (const char*)audio + count, sizeof(data8));
+      left = data8;
+      count += sizeof(data8);
+      if (numChannels == 2) {
+        count += sizeof(data8);
+      }
+    }
+
+    dac_output_voltage(DAC_CHANNEL_1, left);
+    ets_delay_us(delayus);
+
+    if (_playRequested) {
+      setOutputMode(TONE_OUTPUT);
+      return 0;
+    }
+  }
+
+  dac_output_voltage(DAC_CHANNEL_1, 127);
+  setOutputMode(TONE_OUTPUT);
+  return 1;
+}
+
+/**
+ * @brief WAV 再生予約を 1 回だけ取り出す
+ * @return true 再生予約あり
+ * @return false 再生予約なし
+ */
+bool Speaker::takeRequest() {
+  if (_playRequested) {
+    _playRequested = false;
+    return true;
+  }
+
+  return false;
+}

--- a/src/Speaker.h
+++ b/src/Speaker.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <driver/dac.h>
+
+#include "Buzzer.h"
+
+class Speaker : public Buzzer {
+ public:
+  static const uint8_t DEFAULT_SPEAKER_PIN = 25;
+  static const uint8_t DEFAULT_SHUTDOWN_PIN = 14;
+
+  Speaker(uint8_t volumePercent,
+          uint8_t speakerPin = DEFAULT_SPEAKER_PIN,
+          uint8_t shutdownPin = DEFAULT_SHUTDOWN_PIN,
+          uint8_t channel = Buzzer::DEFAULT_CHANNEL);
+  virtual ~Speaker();
+
+  void begin();
+  void enable();
+  void disable();
+  void setVolume(uint8_t percent);
+  void requestWav(const unsigned char* audio, uint32_t length);
+  bool updateWav();
+  bool update() override;
+
+ private:
+  enum OutputMode {
+    TONE_OUTPUT,
+    WAV_OUTPUT
+  };
+
+  void initVolume();
+  void setOutputMode(OutputMode mode);
+  int playWav(const unsigned char* audio, uint32_t length);
+  bool takeRequest();
+
+  uint8_t _shutdownPin;
+  const unsigned char* _audio;
+  uint32_t _length;
+  bool _playRequested;
+  bool _volumeInitialized;
+  uint8_t _initialVolume;
+  bool _begun;
+};

--- a/src/TimedPatternPlayer.cpp
+++ b/src/TimedPatternPlayer.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file TimedPatternPlayer.cpp
+ * @brief 時間付き出力パターンをノンブロッキングで再生する基底クラスの実装
+ */
+
+#include "TimedPatternPlayer.h"
+
+/**
+ * @brief パターン未設定・停止状態で初期化する
+ */
+TimedPatternPlayer::TimedPatternPlayer()
+    : _steps(nullptr),
+      _length(0),
+      _index(0),
+      _stepStartedAt(0),
+      _playing(false),
+      _finished(true) {}
+
+TimedPatternPlayer::~TimedPatternPlayer() {}
+
+/**
+ * @brief 指定したステップ配列の再生を開始する
+ * @param steps 出力ステップ配列
+ * @param length 配列長
+ */
+void TimedPatternPlayer::play(const Step* steps, size_t length) {
+  stop();
+
+  if (steps == nullptr || length == 0) {
+    _finished = true;
+    return;
+  }
+
+  _steps = steps;
+  _length = length;
+  _index = 0;
+  _playing = true;
+  _finished = false;
+  startCurrentStep();
+}
+
+void TimedPatternPlayer::play(Pattern pattern) {
+  play(pattern.steps, pattern.length);
+}
+
+/**
+ * @brief 再生を停止して内部状態を初期化する
+ */
+void TimedPatternPlayer::stop() {
+  if (_playing) {
+    stopOutput();
+  }
+
+  _steps = nullptr;
+  _length = 0;
+  _index = 0;
+  _playing = false;
+  _finished = true;
+}
+
+/**
+ * @brief 現在のステップ再生状態を進める
+ * @return true 再生中
+ * @return false 停止中または再生完了
+ */
+bool TimedPatternPlayer::update() {
+  if (!_playing || _steps == nullptr) {
+    return false;
+  }
+
+  if (millis() - _stepStartedAt < _steps[_index].durationMs) {
+    return true;
+  }
+
+  _index++;
+  if (_index >= _length) {
+    finish();
+    return false;
+  }
+
+  startCurrentStep();
+  return true;
+}
+
+bool TimedPatternPlayer::isPlaying() const {
+  return _playing;
+}
+
+bool TimedPatternPlayer::isFinished() const {
+  return _finished;
+}
+
+/**
+ * @brief 現在位置から再生中パターンを取り出す
+ * @return Pattern 現在の再生位置以降のパターン情報
+ */
+TimedPatternPlayer::Pattern TimedPatternPlayer::capturePlayback() const {
+  if (!_playing || _steps == nullptr || _index >= _length) {
+    return {nullptr, 0};
+  }
+
+  return {_steps + _index, _length - _index};
+}
+
+void TimedPatternPlayer::startCurrentStep() {
+  _stepStartedAt = millis();
+  applyOutput(_steps[_index].output);
+}
+
+/**
+ * @brief 出力を停止して再生完了状態へ遷移する
+ */
+void TimedPatternPlayer::finish() {
+  stopOutput();
+  _steps = nullptr;
+  _length = 0;
+  _index = 0;
+  _playing = false;
+  _finished = true;
+}

--- a/src/TimedPatternPlayer.h
+++ b/src/TimedPatternPlayer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Arduino.h>
+#include <stddef.h>
+
+class TimedPatternPlayer {
+ public:
+  struct Step {
+    uint8_t output;
+    uint16_t durationMs;
+  };
+
+  struct Pattern {
+    const Step* steps;
+    size_t length;
+  };
+
+  TimedPatternPlayer();
+  virtual ~TimedPatternPlayer();
+
+  void play(const Step* steps, size_t length);
+  void play(Pattern pattern);
+  void stop();
+  virtual bool update();
+  bool isPlaying() const;
+  bool isFinished() const;
+  Pattern capturePlayback() const;
+
+ protected:
+  virtual void applyOutput(uint8_t output) = 0;
+  virtual void stopOutput() = 0;
+
+ private:
+  void startCurrentStep();
+  void finish();
+
+  const Step* _steps;
+  size_t _length;
+  size_t _index;
+  uint32_t _stepStartedAt;
+  bool _playing;
+  bool _finished;
+};

--- a/src/Vibrator.cpp
+++ b/src/Vibrator.cpp
@@ -1,0 +1,143 @@
+/**
+ * @file Vibrator.cpp
+ * @brief PWM による振動制御クラスの実装
+ */
+
+#include "Vibrator.h"
+
+/**
+ * @brief 振動モータ制御クラスを生成する
+ * @param pin 出力ピン
+ * @param channel LEDC チャンネル
+ * @param frequency PWM 周波数
+ * @param resolutionBits PWM 分解能
+ */
+Vibrator::Vibrator(uint8_t pin, uint8_t channel, double frequency,
+                   uint8_t resolutionBits)
+    : _pin(pin),
+      _channel(channel),
+      _frequency(frequency),
+      _resolutionBits(resolutionBits),
+      _pwmResolution((1UL << resolutionBits) - 1),
+      _pwmEnabled(false),
+      _begun(false) {}
+
+Vibrator::~Vibrator() {}
+
+/**
+ * @brief 出力ピンと PWM を初期化する
+ */
+void Vibrator::begin() {
+  if (_begun) {
+    return;
+  }
+
+  pinMode(_pin, OUTPUT);
+  digitalWrite(_pin, LOW);
+  ledcSetup(_channel, _frequency, _resolutionBits);
+  _begun = true;
+}
+
+/**
+ * @brief 全開で振動させる
+ */
+void Vibrator::on() {
+  begin();
+  disablePWM();
+  digitalWrite(_pin, HIGH);
+}
+
+/**
+ * @brief 振動強度を百分率で設定する
+ * @param percent 0 から 100 の出力率
+ */
+void Vibrator::setPower(uint8_t percent) {
+  begin();
+
+  if (percent >= 100) {
+    on();
+    return;
+  }
+
+  if (percent == 0) {
+    off();
+    return;
+  }
+
+  enablePWM();
+  uint32_t duty = (uint32_t)percent * _pwmResolution / 100;
+  ledcWrite(_channel, duty);
+}
+
+/**
+ * @brief 振動を停止する
+ */
+void Vibrator::off() {
+  begin();
+  disablePWM();
+  digitalWrite(_pin, LOW);
+}
+
+/**
+ * @brief 現在振動しているかを返す
+ * @return true 振動中
+ * @return false 停止中
+ */
+bool Vibrator::isOn() const {
+  if (!_pwmEnabled) {
+    return digitalRead(_pin) == HIGH;
+  }
+
+  return ledcRead(_channel) > 0;
+}
+
+/**
+ * @brief 振動パターンの再生を開始する
+ * @param pattern パターン配列
+ * @param length 配列長
+ */
+void Vibrator::playPattern(const PowerStep* pattern, size_t length) {
+  play(pattern, length);
+}
+
+void Vibrator::playPattern(Pattern pattern) {
+  play(pattern);
+}
+
+/**
+ * @brief 振動パターンの再生状態を更新する
+ * @return true 再生中
+ * @return false 停止中または再生完了
+ */
+bool Vibrator::update() {
+  begin();
+  return TimedPatternPlayer::update();
+}
+
+void Vibrator::applyOutput(uint8_t output) {
+  setPower(output);
+}
+
+void Vibrator::stopOutput() {
+  off();
+}
+
+/**
+ * @brief PWM 出力へ切り替える
+ */
+void Vibrator::enablePWM() {
+  if (!_pwmEnabled) {
+    ledcAttachPin(_pin, _channel);
+    _pwmEnabled = true;
+  }
+}
+
+/**
+ * @brief 通常 GPIO 出力へ戻す
+ */
+void Vibrator::disablePWM() {
+  if (_pwmEnabled) {
+    ledcDetachPin(_pin);
+    _pwmEnabled = false;
+  }
+}

--- a/src/Vibrator.h
+++ b/src/Vibrator.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Arduino.h>
+#include <stddef.h>
+
+#include "TimedPatternPlayer.h"
+
+class Vibrator : public TimedPatternPlayer {
+ public:
+  using PowerStep = TimedPatternPlayer::Step;
+  using Pattern = TimedPatternPlayer::Pattern;
+
+  static const uint8_t DEFAULT_RESOLUTION_BITS = 8;
+  static constexpr double DEFAULT_FREQUENCY = 1000.0;
+
+  Vibrator(uint8_t pin, uint8_t channel,
+           double frequency = DEFAULT_FREQUENCY,
+           uint8_t resolutionBits = DEFAULT_RESOLUTION_BITS);
+  virtual ~Vibrator();
+
+  void begin();
+  void on();
+  void setPower(uint8_t percent);
+  void off();
+  bool isOn() const;
+  void playPattern(const PowerStep* pattern, size_t length);
+  void playPattern(Pattern pattern);
+  template <size_t N>
+  void playPattern(const PowerStep (&pattern)[N]) {
+    playPattern(pattern, N);
+  }
+  bool update() override;
+
+ protected:
+  void applyOutput(uint8_t output) override;
+  void stopOutput() override;
+
+ private:
+  void enablePWM();
+  void disablePWM();
+
+  uint8_t _pin;
+  uint8_t _channel;
+  double _frequency;
+  uint8_t _resolutionBits;
+  uint32_t _pwmResolution;
+  bool _pwmEnabled;
+  bool _begun;
+};


### PR DESCRIPTION
概要
xsa-kunai 側にあった Buzzer / Vibrator / Speaker を ArduinoCommon へ移行し、時間付きパターン再生の共通基盤として TimedPatternPlayer を追加しました。

これにより、音と振動の出力ロジックを ArduinoCommon 側へ集約し、他プロジェクトでも再利用しやすい構成に整理しています。

変更内容
TimedPatternPlayer を追加

時間付きステップ配列のノンブロッキング再生を共通化
play() / stop() / update() / capturePlayback() を提供
Buzzer を追加

MIDI ノート番号ベースのトーン再生
playTone() / mute() / playMelody() / update()
Vibrator を追加

PWM による振動出力
on() / setPower() / off() / playPattern() / update()
Speaker を追加

Buzzer 継承
トーン再生に加えて DAC による WAV 再生をサポート
setVolume() / requestWav() / updateWav()
README を日本語で更新

examples/Buzzer / examples/Vibrator / examples/Speaker を追加

新規クラスの Doxygen コメントを .cpp 側に日本語で追加

API 方針
従来の終端値ベースの API ではなく、配列長ベースの API に整理しています。

旧方式
NULL_NOTE
NULL_DUTY
終端要素必須
新方式
const Buzzer::Note melody[]
const Vibrator::PowerStep pattern[]
playMelody(melody) / playPattern(pattern) のように配列長を明示的に扱う設計
この変更により、暗黙ルールを減らし、保守性を上げています。
